### PR TITLE
5 & 7: end story

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+story-club/client_secret_897734032411-rcn4pv410paf70f2pvbe4ll5iej0hgp5.apps.googleusercontent.com.json
+story-club/creds.py
+story-club/psyched-axle-269916-e61ccb85d72c.json
+story-club/secret.py

--- a/story-club/pages/01_✏️Generator.py
+++ b/story-club/pages/01_✏️Generator.py
@@ -21,6 +21,7 @@ SERVICE_ACCOUNT_FILE = 'psyched-axle-269916-e61ccb85d72c.json'  # Upload this to
 SHEET_NAME = 'data'
 WORKSHEET_NAME_GEN = 'generated'  # Usually Sheet1 unless renamed
 WORKSHEET_NAME_READY = 'readyup'
+WORKSHEET_NAME_MEMBERS = 'members'
 
 # Auth and connect
 @st.cache_resource
@@ -54,9 +55,22 @@ def shuffle_avoiding_fixed_points(prev, members):
         if all(a != b for a, b in zip(new, prev)):
             return new
 
+def get_col_number(sheet, column_name, header_row=1):
+    """
+    Return 1‑based column number that matches `column_name`.
+    Raises KeyError if not found.
+    """
+    headers = sheet.row_values(header_row)          # list of header strings
+    try:
+        # `.index` is 0‑based → add 1 for Sheets’ 1‑based columns
+        return headers.index(column_name) + 1
+    except ValueError:
+        raise KeyError(f"Column '{column_name}' not found in header row")
+
 # Connecting to Google Sheet
 sheet_gen = connect_to_gsheet(WORKSHEET_NAME_GEN)
 sheet_ready = connect_to_gsheet(WORKSHEET_NAME_READY)
+sheet_members = connect_to_gsheet(WORKSHEET_NAME_MEMBERS)
 
 # Read as DataFrame
 generated_data = sheet_gen.get_all_records()
@@ -65,120 +79,172 @@ categories_df = pd.DataFrame(generated_data)[columns_to_get]
 data_ready = sheet_ready.get_all_records()
 ready_df = pd.DataFrame(data_ready)
 
-max_upload = categories_df.upload_number.max()
+data_members = sheet_members.get_all_records()
+members_df = pd.DataFrame(data_members)
 
-st.write(ready_df)
+member_list = list(members_df['member'].values)
+
+max_upload = categories_df.upload_number.max()
+max_due_date = dt.datetime.strptime(categories_df.loc[max_upload,'due_date'], "%Y-%m-%d").date()
+today = dt.date.today()
+days_left = max_due_date - today
+
+# summing flags
+sum_flags = 0
+for member in member_list:
+    sum_flags += ready_df.loc[0, member]
 
 def main():
-    # initializing variables
-    if "click_save" not in st.session_state:
-        st.session_state.click_save = False
+    if sum_flags == len(member_list):
+        # initializing variables
+        if "click_save" not in st.session_state:
+            st.session_state.click_save = False
 
-    st.title("Generate Your Story")
+        st.title("Generate Your Story")
 
-    # setting the story length odds
-    odds_500 = 0.1
-    odds_1000 = 0.2
-    odds_1500 = 0.35
-    odds_2000 = 0.2
-    odds_2500 = 0.1
-    odds_3000 = 0.05
+        # setting the story length odds
+        odds_500 = 0.1
+        odds_1000 = 0.2
+        odds_1500 = 0.35
+        odds_2000 = 0.2
+        odds_2500 = 0.1
+        odds_3000 = 0.05
 
-    with st.expander('Story Length Odds'):
-        st.info(f'Odds of story length are {odds_500*100}% for 500 words, {odds_1000*100}% for 1000,  '
-                f'{odds_1500*100}% for 1500, {odds_2000*100}% for 2000 words, {odds_2500*100}% for 2500, and {odds_3000*100}% for 3000 words. '
-                'There are 5 Days assigned per 100 words of story selected. ')
+        with st.expander('Story Length Odds'):
+            st.info(f'Odds of story length are {odds_500*100}% for 500 words, {odds_1000*100}% for 1000,  '
+                    f'{odds_1500*100}% for 1500, {odds_2000*100}% for 2000 words, {odds_2500*100}% for 2500, and {odds_3000*100}% for 3000 words. '
+                    'There are 5 Days assigned per 100 words of story selected. ')
 
-    member_list = ['Alvaro', 'Elijah', 'Favier', 'Raffy']
+        image = 'gifs/tars.gif'
 
-    image = 'gifs/tars.gif'
+        # setting the chosen categories to blank if randomize hasn't been hit yet
+        if 'object' not in st.session_state:
+            for category in categories:
+                st.session_state[category] = ''
+            st.session_state.word_count = 0
+            st.session_state.due_date = dt.date.today()
 
-    # setting the chosen categories to blank if randomize hasn't been hit yet
-    if 'object' not in st.session_state:
-        for category in categories:
-            st.session_state[category] = ''
-        st.session_state.word_count = 0
-        st.session_state.due_date = dt.date.today()
+        if st.button('Randomize'):
 
-    if st.button('Randomize'):
+            st.session_state.message = "Update"
 
-        st.session_state.message = "Update"
+            # gets the previous list of categories and who chose them, so that the new list doesn't repeat
+            prev = []
+            for category in categories:
+                prev.append(categories_df.loc[max_upload, category])
 
-        # gets the previous list of categories and who chose them, so that the new list doesn't repeat
-        prev = []
-        for category in categories:
-            prev.append(categories_df.loc[max_upload, category])
+            new_list = shuffle_avoiding_fixed_points(prev, member_list)
 
-        new_list = shuffle_avoiding_fixed_points(prev, member_list)
+            # sets the session states for each category to the chosen member
+            for category, i in zip(categories, np.arange(0,len(new_list))):
+                st.session_state[category] = new_list[i]
 
-        # sets the session states for each category to the chosen member
-        for category, i in zip(categories, np.arange(0,len(new_list))):
-            st.session_state[category] = new_list[i]
+            # sets the word_count session state depending on what random number has been generated
+            rand = np.random.random()
+            if rand < odds_500:
+                st.session_state.word_count = 500
+                image = 'gifs/blackhole.gif'
+            elif rand >= odds_500 and rand < odds_500 + odds_1000:
+                st.session_state.word_count = 1000
+                image = 'gifs/necessary.gif'
+            elif rand >= odds_500 + odds_1000 and rand < odds_500 + odds_1000 + odds_1500:
+                st.session_state.word_count = 1500
+                image = 'gifs/yes.gif'
+            elif rand >= odds_500 + odds_1000 + odds_1500 and rand < odds_500 + odds_1000 + odds_1500 + odds_2000:
+                st.session_state.word_count = 2000
+                image = 'gifs/humor.gif'
+            elif rand >= odds_500 + odds_1000 + odds_1500 + odds_2000 and rand < odds_500 + odds_1000 + odds_1500 + odds_2000 + odds_2500:
+                st.session_state.word_count = 2500
+                image = 'gifs/interstellar-cost.gif'
+            else:
+                st.session_state.word_count = 3000
+                image = 'gifs/crying.gif'
 
-        # sets the word_count session state depending on what random number has been generated
-        rand = np.random.random()
-        if rand < odds_500:
-            st.session_state.word_count = 500
-            image = 'gifs/blackhole.gif'
-        elif rand >= odds_500 and rand < odds_500 + odds_1000:
-            st.session_state.word_count = 1000
-            image = 'gifs/necessary.gif'
-        elif rand >= odds_500 + odds_1000 and rand < odds_500 + odds_1000 + odds_1500:
-            st.session_state.word_count = 1500
-            image = 'gifs/yes.gif'
-        elif rand >= odds_500 + odds_1000 + odds_1500 and rand < odds_500 + odds_1000 + odds_1500 + odds_2000:
-            st.session_state.word_count = 2000
-            image = 'gifs/humor.gif'
-        elif rand >= odds_500 + odds_1000 + odds_1500 + odds_2000 and rand < odds_500 + odds_1000 + odds_1500 + odds_2000 + odds_2500:
-            st.session_state.word_count = 2500
-            image = 'gifs/interstellar-cost.gif'
-        else:
-            st.session_state.word_count = 3000
-            image = 'gifs/crying.gif'
+            # calculated the due date based on the word length
+            days_to_add = dt.timedelta(days=(st.session_state.word_count/100)+1)
 
-        # calculated the due date based on the word length
-        days_to_add = dt.timedelta(days=(st.session_state.word_count/100)+1)
+            due_date = dt.date.today() + days_to_add
+            st.session_state.due_date = due_date
 
-        due_date = dt.date.today() + days_to_add
-        st.session_state.due_date = due_date
+        c1,c2 = st.columns(2)
+        with (c1):
 
-    c1,c2 = st.columns(2)
-    with (c1):
+            # printing categories and who is selecting (or nothing)
+            st.write('Object / Noun: {}'.format(st.session_state.object))
 
-        # printing categories and who is selecting (or nothing)
-        st.write('Object / Noun: {}'.format(st.session_state.object))
+            st.write('Emotion: {}'.format(st.session_state.emotion))
 
-        st.write('Emotion: {}'.format(st.session_state.emotion))
+            st.write('Action / Verb: {}'.format(st.session_state.action))
 
-        st.write('Action / Verb: {}'.format(st.session_state.action))
+            st.write('Setting / Location: {}'.format(st.session_state.setting))
 
-        st.write('Setting / Location: {}'.format(st.session_state.setting))
+            st.write(f"Word Count = {st.session_state.word_count} and it is due {st.session_state.due_date}")
 
-        st.write(f"Word Count = {st.session_state.word_count} and it is due {st.session_state.due_date}")
+            st.warning('WARNING! Do not click "Save Categories" unless you are ready for the next story')
+            if st.button('Save Categories'):
+                st.session_state.click_save = True
 
-        st.warning('WARNING! Do not click "Save Categories" unless you are ready for the next story')
-        if st.button('Save Categories'):
-            st.session_state.click_save = True
+            if st.session_state.click_save:
+                user_pass = st.text_input('Enter Password')
+                if user_pass == '':
+                    pass
+                elif user_pass == password:
+                    new_row = {'upload_number':max_upload+1,'upload_date': dt.date.today(), 'object': st.session_state.object,
+                               'action': st.session_state.action, 'emotion': st.session_state.emotion,
+                               'setting': st.session_state.setting, 'word_count': st.session_state.word_count,
+                               'due_date':st.session_state.due_date}
+                    try:
+                        sheet_gen.append_row([str(value) for value in new_row.values()])
+                        st.write('Categories Saved! Check the Current Story tab to see how long you have left.')
+                        st.session_state.click_save = False
+                    except Exception as e:
+                        st.error(f"Failed to add row: {e}")
 
-        if st.session_state.click_save:
+                else:
+                    st.write('Incorrect Password. Try Again')
+        with c2:
+            st.markdown(get_image_download_link(parent_folder / image), unsafe_allow_html=True)
+    else:
+        # initializing variables
+        if "ready" not in st.session_state:
+            st.session_state.ready = False
+
+        st.header('Ready Up to Get Started on your Next Story!')
+        c1, c2, c3, c4 = st.columns(4)
+        with c1:
+            if sum_flags >= 1:
+                st.header('🚩')
+            else:
+                st.write('❌')
+        with c2:
+            if sum_flags >= 2:
+                st.header('🚩')
+            else:
+                st.write('❌')
+        with c3:
+            if sum_flags >= 3:
+                st.header('🚩')
+            else:
+                st.write('❌')
+        with c4:
+            if sum_flags >= 4:
+                st.header('🚩')
+            else:
+                st.write('❌')
+        member_select = st.selectbox(options = member_list, label = 'Ready Up')
+        if st.button("I'm Ready"):
+            st.session_state.ready = True
+        if st.session_state.ready:
             user_pass = st.text_input('Enter Password')
             if user_pass == '':
                 pass
             elif user_pass == password:
-                new_row = {'upload_number':max_upload+1,'upload_date': dt.date.today(), 'object': st.session_state.object,
-                           'action': st.session_state.action, 'emotion': st.session_state.emotion,
-                           'setting': st.session_state.setting, 'word_count': st.session_state.word_count,
-                           'due_date':st.session_state.due_date}
-                try:
-                    sheet_gen.append_row([str(value) for value in new_row.values()])
-                    st.write('Categories Saved! Check the Current Story tab to see how long you have left.')
-                    st.session_state.click_save = False
-                except Exception as e:
-                    st.error(f"Failed to add row: {e}")
-
+                update_col = get_col_number(sheet_ready, member_select)
+                sheet_ready.update_cell(2, update_col, 1)
+                st.write(f'Thanks for Readying Up {member_select}')
+                st.session_state.ready = False # reset session state
             else:
                 st.write('Incorrect Password. Try Again')
-    with c2:
-        st.markdown(get_image_download_link(parent_folder / image), unsafe_allow_html=True)
+
 if __name__ == '__main__':
     main()

--- a/story-club/pages/01_✏️Generator.py
+++ b/story-club/pages/01_✏️Generator.py
@@ -26,15 +26,15 @@ WORKSHEET_NAME_READY = 'readyup'
 @st.cache_resource
 def connect_to_gsheet(worksheet_name):
     # Uncomment for Local Development
-    creds = service_account.Credentials.from_service_account_file(
-        SERVICE_ACCOUNT_FILE,
-        scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
-    )
-    # Uncomment for Deployed
-    # creds = service_account.Credentials.from_service_account_info(
-    #     st.secrets["gcp_service_account"],
+    # creds = service_account.Credentials.from_service_account_file(
+    #     SERVICE_ACCOUNT_FILE,
     #     scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
     # )
+    # Uncomment for Deployed
+    creds = service_account.Credentials.from_service_account_info(
+        st.secrets["gcp_service_account"],
+        scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
+    )
     gc = gspread.authorize(creds)
     sh = gc.open(SHEET_NAME)
     return sh.worksheet(worksheet_name)

--- a/story-club/pages/01_✏️Generator.py
+++ b/story-club/pages/01_✏️Generator.py
@@ -197,6 +197,7 @@ def main():
                         sheet_gen.append_row([str(value) for value in new_row.values()])
                         st.write('Categories Saved! Check the Current Story tab to see how long you have left.')
                         st.session_state.click_save = False
+                        st.rerun()
                     except Exception as e:
                         st.error(f"Failed to add row: {e}")
 
@@ -243,6 +244,7 @@ def main():
                 sheet_ready.update_cell(2, update_col, 1)
                 st.write(f'Thanks for Readying Up {member_select}')
                 st.session_state.ready = False # reset session state
+                st.rerun() # re-run the page so that the flag pops up
             else:
                 st.write('Incorrect Password. Try Again')
 

--- a/story-club/pages/02_⏲️Current_Story.py
+++ b/story-club/pages/02_⏲️Current_Story.py
@@ -98,9 +98,9 @@ if max_upload_number not in (selected_df.upload_number):
 
 if days_left.days >= 0:
     st.header(f'You have {days_left.days} days left to write your story!')
-    st.subheader(f'Your story is due {max_data.loc[max_upload_number, 'due_date']} and '
-                 f'should be between {round(max_data.loc[max_upload_number, 'word_count']-max_data.loc[max_upload_number, 'word_count']/10)} and'
-                 f' {round(max_data.loc[max_upload_number, 'word_count']+max_data.loc[max_upload_number, 'word_count']/10)} words long')
+    st.subheader(f"Your story is due {max_data.loc[max_upload_number, 'due_date']} and "
+                 f"should be between {round(max_data.loc[max_upload_number, 'word_count']-max_data.loc[max_upload_number, 'word_count']/10)} and"
+                 f" {round(max_data.loc[max_upload_number, 'word_count']+max_data.loc[max_upload_number, 'word_count']/10)} words long")
 
     if max_data.loc[max_upload_number,'object_selected'] == '' or max_data.loc[max_upload_number,'emotion_selected'] == ''\
              or max_data.loc[max_upload_number,'action_selected'] == '' or max_data.loc[max_upload_number,'setting_selected'] == '':

--- a/story-club/pages/02_⏲️Current_Story.py
+++ b/story-club/pages/02_⏲️Current_Story.py
@@ -21,15 +21,15 @@ WORKSHEET_NAME_READY = 'readyup'
 @st.cache_resource
 def connect_to_gsheet(worksheet_name):
     # Uncomment for Local Development
-    creds = service_account.Credentials.from_service_account_file(
-        SERVICE_ACCOUNT_FILE,
-        scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
-    )
+    # creds = service_account.Credentials.from_service_account_file(
+    #     SERVICE_ACCOUNT_FILE,
+    #     scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
+    # )
     # Uncomment for Deployed
-    # creds = service_account.Credentials.from_service_account_info(
-    #         st.secrets["gcp_service_account"],
-    #         scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
-    #     )
+    creds = service_account.Credentials.from_service_account_info(
+            st.secrets["gcp_service_account"],
+            scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
+        )
     gc = gspread.authorize(creds)
     sh = gc.open(SHEET_NAME)
     return sh.worksheet(worksheet_name)

--- a/story-club/pages/02_⏲️Current_Story.py
+++ b/story-club/pages/02_⏲️Current_Story.py
@@ -21,15 +21,15 @@ WORKSHEET_NAME_READY = 'readyup'
 @st.cache_resource
 def connect_to_gsheet(worksheet_name):
     # Uncomment for Local Development
-    # creds = service_account.Credentials.from_service_account_file(
-    #     SERVICE_ACCOUNT_FILE,
-    #     scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
-    # )
+    creds = service_account.Credentials.from_service_account_file(
+        SERVICE_ACCOUNT_FILE,
+        scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
+    )
     # Uncomment for Deployed
-    creds = service_account.Credentials.from_service_account_info(
-            st.secrets["gcp_service_account"],
-            scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
-        )
+    # creds = service_account.Credentials.from_service_account_info(
+    #         st.secrets["gcp_service_account"],
+    #         scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
+    #     )
     gc = gspread.authorize(creds)
     sh = gc.open(SHEET_NAME)
     return sh.worksheet(worksheet_name)
@@ -133,7 +133,28 @@ else:
             sheet_ready.update_cell(2, update_col, 0)
         update_col = get_col_number(sheet_ready, 'story_end')
         sheet_ready.update_cell(2, update_col, str(dt.date.today()))
-
+    c1, c2, c3, c4 = st.columns(4)
+    st.write()
+    with c1:
+        if sum_flags >= 1:
+            st.header('🚩')
+        else:
+            st.write('')
+    with c2:
+        if sum_flags >= 2:
+            st.header('🚩')
+        else:
+            st.write('')
+    with c3:
+        if sum_flags >= 3:
+            st.header('🚩')
+        else:
+            st.write('')
+    with c4:
+        if sum_flags >= 4:
+            st.header('🚩')
+        else:
+            st.write('')
 
 
 

--- a/story-club/pages/02_⏲️Current_Story.py
+++ b/story-club/pages/02_⏲️Current_Story.py
@@ -21,15 +21,15 @@ WORKSHEET_NAME_READY = 'readyup'
 @st.cache_resource
 def connect_to_gsheet(worksheet_name):
     # Uncomment for Local Development
-    creds = service_account.Credentials.from_service_account_file(
-        SERVICE_ACCOUNT_FILE,
-        scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
-    )
+    # creds = service_account.Credentials.from_service_account_file(
+    #     SERVICE_ACCOUNT_FILE,
+    #     scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
+    # )
     # Uncomment for Deployed
-    # creds = service_account.Credentials.from_service_account_info(
-    #         st.secrets["gcp_service_account"],
-    #         scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
-    #     )
+    creds = service_account.Credentials.from_service_account_info(
+            st.secrets["gcp_service_account"],
+            scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
+        )
     gc = gspread.authorize(creds)
     sh = gc.open(SHEET_NAME)
     return sh.worksheet(worksheet_name)
@@ -45,6 +45,23 @@ def get_col_number(sheet, column_name, header_row=1):
         return headers.index(column_name) + 1
     except ValueError:
         raise KeyError(f"Column '{column_name}' not found in header row")
+
+def print_prev_stories(df):
+    """
+    prints out a table of previous story selections
+    :param df: joined_df
+    :return: df of previous stories
+    """
+    with st.expander('Click to Show Previous Choices'):
+        prev_df = pd.DataFrame()
+        prev_df['upload_number'] = df['upload_number']
+        prev_df['due_date'] = df['due_date']
+        prev_df['word_count'] = df['word_count']
+
+        for category in categories:
+            prev_df[category] = df[f'{category}_category'].astype(str) + " : " + df[f'{category}_selected'].astype(str)
+
+        return st.table(prev_df[prev_df['upload_number'] != max_upload_number])
 
 # Importing and saving Google Sheets
 sheet_gen = connect_to_gsheet(WORKSHEET_NAME_GEN)
@@ -105,19 +122,10 @@ if days_left.days >= 0:
                                                              max_data.loc[max_upload_number,f'{category}_selected'].capitalize(),
                                                              category.capitalize()))
 
+    print_prev_stories(joined)
 
-    with st.expander('Click to Show Previous Choices'):
-        prev_df = pd.DataFrame()
-        prev_df['upload_number'] = joined['upload_number']
-        prev_df['due_date'] = joined['due_date']
-        prev_df['word_count'] = joined['word_count']
-
-        for category in categories:
-            prev_df[category] = joined[f'{category}_category'].astype(str) + " : " + joined[f'{category}_selected'].astype(str)
-
-        st.table(prev_df[prev_df['upload_number'] != max_upload_number])
 else:
-    st.header("Ready Up to get started on your next story!")
+    st.header("Head to the Generator Page to Ready Up")
     member_list = [x for x in ready_df.columns if x != 'story_end']
     member_count = len(member_list)
     sum_flags = 0
@@ -139,22 +147,25 @@ else:
         if sum_flags >= 1:
             st.header('🚩')
         else:
-            st.write('')
+            st.write('❌')
     with c2:
         if sum_flags >= 2:
             st.header('🚩')
         else:
-            st.write('')
+            st.write('❌')
     with c3:
         if sum_flags >= 3:
             st.header('🚩')
         else:
-            st.write('')
+            st.write('❌')
     with c4:
         if sum_flags >= 4:
             st.header('🚩')
         else:
-            st.write('')
+            st.write('❌')
+
+    print_prev_stories(joined)
+
 
 
 

--- a/story-club/pages/02_⏲️Current_Story.py
+++ b/story-club/pages/02_⏲️Current_Story.py
@@ -15,38 +15,55 @@ SERVICE_ACCOUNT_FILE = 'psyched-axle-269916-e61ccb85d72c.json'  # Upload this to
 SHEET_NAME = 'data'
 WORKSHEET_NAME_GEN = 'generated'  # Usually Sheet1 unless renamed
 WORKSHEET_NAME_CHOSE = 'chosen'
+WORKSHEET_NAME_READY = 'readyup'
 
 # Auth and connect
 @st.cache_resource
 def connect_to_gsheet(worksheet_name):
     # Uncomment for Local Development
-    # creds = service_account.Credentials.from_service_account_file(
-    #     SERVICE_ACCOUNT_FILE,
-    #     scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
-    # )
+    creds = service_account.Credentials.from_service_account_file(
+        SERVICE_ACCOUNT_FILE,
+        scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
+    )
     # Uncomment for Deployed
-    creds = service_account.Credentials.from_service_account_info(
-            st.secrets["gcp_service_account"],
-            scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
-        )
+    # creds = service_account.Credentials.from_service_account_info(
+    #         st.secrets["gcp_service_account"],
+    #         scopes=[ "https://www.googleapis.com/auth/drive", "https://www.googleapis.com/auth/spreadsheets"]
+    #     )
     gc = gspread.authorize(creds)
     sh = gc.open(SHEET_NAME)
     return sh.worksheet(worksheet_name)
 
+def get_col_number(sheet, column_name, header_row=1):
+    """
+    Return 1‑based column number that matches `column_name`.
+    Raises KeyError if not found.
+    """
+    headers = sheet.row_values(header_row)          # list of header strings
+    try:
+        # `.index` is 0‑based → add 1 for Sheets’ 1‑based columns
+        return headers.index(column_name) + 1
+    except ValueError:
+        raise KeyError(f"Column '{column_name}' not found in header row")
 
+# Importing and saving Google Sheets
 sheet_gen = connect_to_gsheet(WORKSHEET_NAME_GEN)
 sheet_chose = connect_to_gsheet(WORKSHEET_NAME_CHOSE)
+sheet_ready = connect_to_gsheet(WORKSHEET_NAME_READY)
 
 data_gen = sheet_gen.get_all_records()
 data_chose = sheet_chose.get_all_records()
+data_ready = sheet_ready.get_all_records()
 
 categories_df = pd.DataFrame(data_gen)[columns_to_get]
 selected_df = pd.DataFrame(data_chose)
+ready_df = pd.DataFrame(data_ready)
 
 today = dt.date.today()
 
 joined = categories_df.join(selected_df, lsuffix = '_category', rsuffix = '_selected', on = 'upload_number')
 
+# Getting data for the latest story
 max_upload_number = joined["upload_number_category"].max()
 max_upload_date = joined["upload_date_category"].max()
 
@@ -62,42 +79,60 @@ if max_upload_number not in (selected_df.upload_number):
 
     sheet_chose.append_row([str(value) for value in new_row.values()])
 
-st.header(f'You have {days_left.days} days left to write your story!')
-st.subheader(f'Your story is due {max_data.loc[max_upload_number, 'due_date']} and '
-             f'should be between {round(max_data.loc[max_upload_number, 'word_count']-max_data.loc[max_upload_number, 'word_count']/10)} and'
-             f' {round(max_data.loc[max_upload_number, 'word_count']+max_data.loc[max_upload_number, 'word_count']/10)} words long')
+if days_left.days >= 0:
+    st.header(f'You have {days_left.days} days left to write your story!')
+    st.subheader(f'Your story is due {max_data.loc[max_upload_number, 'due_date']} and '
+                 f'should be between {round(max_data.loc[max_upload_number, 'word_count']-max_data.loc[max_upload_number, 'word_count']/10)} and'
+                 f' {round(max_data.loc[max_upload_number, 'word_count']+max_data.loc[max_upload_number, 'word_count']/10)} words long')
 
-if max_data.loc[max_upload_number,'object_selected'] == '' or max_data.loc[max_upload_number,'emotion_selected'] == ''\
-         or max_data.loc[max_upload_number,'action_selected'] == '' or max_data.loc[max_upload_number,'setting_selected'] == '':
-    st.write("Not everyone has chosen words for their selected Category. Please return when that is done!")
-    st.write('For this story:')
-    for category in categories:
-        st.markdown("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{} is choosing in the {} category".format(max_data.loc[max_upload_number, f'{category}_category'],
-                                                     category.capitalize()))
-elif pd.isna(max_data.loc[max_upload_number,'object_selected']) or pd.isna(max_data.loc[max_upload_number,'emotion_selected'])\
-         or pd.isna(max_data.loc[max_upload_number,'action_selected']) or pd.isna(max_data.loc[max_upload_number,'setting_selected']):
-    st.write("Not everyone has chosen words for their selected Category. Please return when that is done!")
-    st.write('For this story:')
-    for category in categories:
-        st.markdown("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{} is choosing in the {} category".format(max_data.loc[max_upload_number, f'{category}_category'],
-                                                     category.capitalize()))
-else:
-    for category in categories:
-        st.write('{} chose {} in the {} category'.format(max_data.loc[max_upload_number,f'{category}_category'],
-                                                         max_data.loc[max_upload_number,f'{category}_selected'].capitalize(),
+    if max_data.loc[max_upload_number,'object_selected'] == '' or max_data.loc[max_upload_number,'emotion_selected'] == ''\
+             or max_data.loc[max_upload_number,'action_selected'] == '' or max_data.loc[max_upload_number,'setting_selected'] == '':
+        st.write("Not everyone has chosen words for their selected Category. Please return when that is done!")
+        st.write('For this story:')
+        for category in categories:
+            st.markdown("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{} is choosing in the {} category".format(max_data.loc[max_upload_number, f'{category}_category'],
                                                          category.capitalize()))
+    elif pd.isna(max_data.loc[max_upload_number,'object_selected']) or pd.isna(max_data.loc[max_upload_number,'emotion_selected'])\
+             or pd.isna(max_data.loc[max_upload_number,'action_selected']) or pd.isna(max_data.loc[max_upload_number,'setting_selected']):
+        st.write("Not everyone has chosen words for their selected Category. Please return when that is done!")
+        st.write('For this story:')
+        for category in categories:
+            st.markdown("&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;{} is choosing in the {} category".format(max_data.loc[max_upload_number, f'{category}_category'],
+                                                         category.capitalize()))
+    else:
+        for category in categories:
+            st.write('{} chose {} in the {} category'.format(max_data.loc[max_upload_number,f'{category}_category'],
+                                                             max_data.loc[max_upload_number,f'{category}_selected'].capitalize(),
+                                                             category.capitalize()))
 
 
-with st.expander('Click to Show Previous Choices'):
-    prev_df = pd.DataFrame()
-    prev_df['upload_number'] = joined['upload_number']
-    prev_df['due_date'] = joined['due_date']
-    prev_df['word_count'] = joined['word_count']
+    with st.expander('Click to Show Previous Choices'):
+        prev_df = pd.DataFrame()
+        prev_df['upload_number'] = joined['upload_number']
+        prev_df['due_date'] = joined['due_date']
+        prev_df['word_count'] = joined['word_count']
 
-    for category in categories:
-        prev_df[category] = joined[f'{category}_category'].astype(str) + " : " + joined[f'{category}_selected'].astype(str)
+        for category in categories:
+            prev_df[category] = joined[f'{category}_category'].astype(str) + " : " + joined[f'{category}_selected'].astype(str)
 
-    st.table(prev_df[prev_df['upload_number'] != max_upload_number])
+        st.table(prev_df[prev_df['upload_number'] != max_upload_number])
+else:
+    st.header("Ready Up to get started on your next story!")
+    member_list = [x for x in ready_df.columns if x != 'story_end']
+    member_count = len(member_list)
+    sum_flags = 0
+    for member in member_list:
+        sum_flags += ready_df.loc[0, member]
+
+    # Reset the ready flags ONLY if the last due date is after the last time it was reset (to prevent resetting mid story),
+    # the due date is already past, and if all flags are 1
+    if (ready_df.loc[0, 'story_end'] < max_data.loc[max_upload_number, 'due_date']) & \
+        (days_left.days < 0) & (member_count == sum_flags):
+        for member in member_list:
+            update_col = get_col_number(sheet_ready, member)
+            sheet_ready.update_cell(2, update_col, 0)
+        update_col = get_col_number(sheet_ready, 'story_end')
+        sheet_ready.update_cell(2, update_col, str(dt.date.today()))
 
 
 

--- a/story-club/pages/03_🧠Category_Input.py
+++ b/story-club/pages/03_🧠Category_Input.py
@@ -114,6 +114,7 @@ if cat_selection:
 
                 st.write('Word Saved! Check the "Current Story" tab once everyone is done submitting their word.')
                 st.session_state.save_word = False
+                st.rerun()
             else:
                 st.write('Incorrect Password. Try Again')
 


### PR DESCRIPTION
also part of 6 

This is what the Current Story Page looks like. Number of flags is based on how many people have readied up. 
<img width="961" height="615" alt="image" src="https://github.com/user-attachments/assets/f527bd85-4b2a-4514-bd6a-3669b2147de4" />

The logic is, only when the most recent due date is AFTER the last time the flags were reset (to prevent early flag deletions), when the due date is ALREADY PAST, and only if all 4 flags are up, do the flags all reset to 0. 

Once the story is generated and theres a new due date, the old page comes back up. 

I tested by generating a fake story and modifying the due date to be after story_end, and it changed all of the flags to 0 and the story_end date to today
